### PR TITLE
Prevent deprecation warning on LU

### DIFF
--- a/src/lu.jl
+++ b/src/lu.jl
@@ -93,7 +93,7 @@ function lu!(A::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer},
         info = _generic_lufact!(A, pivot, ipiv, info)
     end
     check && checknonsingular(info)
-    LU{T, typeof(A), typeof(ipiv)}(A, ipiv, info)
+    LU(A, ipiv, info)
 end
 
 @inline function recurse!(A, ::Val{Pivot}, m, n, mnmin, ipiv, info, blocksize,

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -93,7 +93,7 @@ function lu!(A::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer},
         info = _generic_lufact!(A, pivot, ipiv, info)
     end
     check && checknonsingular(info)
-    LU{T, typeof(A)}(A, ipiv, info)
+    LU{T, typeof(A), typeof(ipiv)}(A, ipiv, info)
 end
 
 @inline function recurse!(A, ::Val{Pivot}, m, n, mnmin, ipiv, info, blocksize,


### PR DESCRIPTION
I get this deprecation warning from my [tests](https://github.com/KnutAM/Newton.jl/actions/runs/3517881630/jobs/5896162890#step:6:140):
```julia
┌ Warning: `LU{T, S}(factors::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer}, info::BlasInt) where {T, S}` is deprecated, use `LU{T, S, typeof(ipiv)}(factors, ipiv, info)` instead.
│   caller = ip:0x0
└ @ Core :-1
```
(I don't understand why, but I don't see it when calling from the REPL)
As far as I can see, there is no need to provide any type-params to [LU](https://github.com/JuliaLang/LinearAlgebra.jl/blob/8108bc4ff2dbd5b2143d6279efad640952f97f8e/src/lu.jl#L60)
(Sorry if I'm way off here, just wanted to avoid the warning during my tests. I suppose it isn't so crucial as the comment in LU says will be deprecated at Julia 2.0)