### PR TITLE
Turbo findmax

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveFactorization"
 uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>"]
-version = "0.2.19"
+version = "0.2.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -278,7 +278,7 @@ function _generic_lufact!(A, ::Val{Pivot}, ipiv, info) where {Pivot}
             kp = k
             if Pivot
                 amax = abs(zero(eltype(A)))
-                @turbo for i in k:m
+                @turbo warn_check_args=false for i in k:m
                     absi = abs(A[i, k])
                     isnewmax = absi > amax
                     kp = isnewmax ? i : kp
@@ -289,7 +289,7 @@ function _generic_lufact!(A, ::Val{Pivot}, ipiv, info) where {Pivot}
             if !iszero(A[kp, k])
                 if k != kp
                     # Interchange
-                    @simd warn_check_args=false for i in 1:n
+                    @simd for i in 1:n
                         tmp = A[k, i]
                         A[k, i] = A[kp, i]
                         A[kp, i] = tmp

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -144,7 +144,6 @@ end
 end
 
 @inline function nsplit(::Type{T}, n) where {T}
-    # k = max(2, 512 ÷ (isbitstype(T) ? sizeof(T) : 8))
     k = max(2, 128 ÷ (isbitstype(T) ? sizeof(T) : 8))
     k_2 = k ÷ 2
     return n >= k ? ((n + k_2) ÷ k) * k_2 : n ÷ 2

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -289,7 +289,7 @@ function _generic_lufact!(A, ::Val{Pivot}, ipiv, info) where {Pivot}
             if !iszero(A[kp, k])
                 if k != kp
                     # Interchange
-                    @simd for i in 1:n
+                    @simd warn_check_args=false for i in 1:n
                         tmp = A[k, i]
                         A[k, i] = A[kp, i]
                         A[kp, i] = tmp

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -144,7 +144,8 @@ end
 end
 
 @inline function nsplit(::Type{T}, n) where {T}
-    k = max(2, 512 ÷ (isbitstype(T) ? sizeof(T) : 8))
+    # k = max(2, 512 ÷ (isbitstype(T) ? sizeof(T) : 8))
+    k = max(2, 128 ÷ (isbitstype(T) ? sizeof(T) : 8))
     k_2 = k ÷ 2
     return n >= k ? ((n + k_2) ÷ k) * k_2 : n ÷ 2
 end
@@ -277,12 +278,11 @@ function _generic_lufact!(A, ::Val{Pivot}, ipiv, info) where {Pivot}
             kp = k
             if Pivot
                 amax = abs(zero(eltype(A)))
-                for i in k:m
+                @turbo for i in k:m
                     absi = abs(A[i, k])
-                    if absi > amax
-                        kp = i
-                        amax = absi
-                    end
+                    isnewmax = absi > amax
+                    kp = isnewmax ? i : kp
+                    amax = isnewmax ? absi : amax
                 end
                 ipiv[k] = kp
             end


### PR DESCRIPTION
After:
```julia
julia> @benchmark RecursiveFactorization.lu!(copyto!($B,$A), $ipiv,Val(true),Val(false), blocksize=8)
BenchmarkTools.Trial: 2562 samples with 1 evaluation.
 Range (min … max):  384.506 μs … 399.233 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     386.841 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   387.488 μs ±   1.524 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                ▃▂▄▄▅█▅▂▁▂                                       
  ▂▁▁▁▂▂▂▃▃▄▆▅▇████████████▇▅▄▄▃▃▃▃▃▃▃▄▄▅▄▆▆▇▇▇▇▇▇█▆▇▆▇▅▅▄▃▃▃▃▃ ▄
  385 μs           Histogram: frequency by time          391 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
Before:
```julia
julia> @benchmark RecursiveFactorization.lu!(copyto!($B,$A), $ipiv,Val(true),Val(false), blocksize=8)
BenchmarkTools.Trial: 2318 samples with 1 evaluation.
 Range (min … max):  426.292 μs … 445.566 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     428.158 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   428.777 μs ±   1.491 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▁▂▄▆▆█▅▆▆▆▁▃▁                    ▁▁▁▁▃▁ ▂▁            
  ▂▂▂▂▃▅▄▅██████████████▇▇▄▃▃▂▁▂▂▂▂▂▃▅▄▄▄▅▇▆██████▆██▇▆▆▄▄▃▃▃▃▃ ▄
  426 μs           Histogram: frequency by time          432 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
Setup:
```julia
@time using RecursiveFactorization
A = rand(300,300);
B = similar(A);
ipiv = Vector{Int}(undef,300);
```

Benchmarks across all sizes `4:500`, RF 0.2.19:
![lubenchrf19](https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/assets/8043603/fee9812f-d610-4e91-bb3b-6a11bad94e23)
![lubenchturbofindma](https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/assets/8043603/82468c92-0b72-41d6-8f2d-a15f98770e99)
versus PR on bottom.

Summary stats of relative differences:
```julia
julia> StatsBase.summarystats(respr ./ res19)
Summary Stats:
Length:         497
Missing Count:  0
Mean:           1.086197
Minimum:        0.889275
1st Quartile:   1.059688
Median:         1.092518
3rd Quartile:   1.120472
Maximum:        1.254754
```
So, 8.6% increase in GFLOPS on average on
```julia
julia> versioninfo()
Julia Version 1.9.3-DEV.0
Commit 6fc1be04ee (2023-07-06 14:55 UTC)
Platform Info:
  OS: Linux (x86_64-generic-linux)
  CPU: 36 × Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, cascadelake)
  Threads: 1 on 36 virtual cores
```