### PR TITLE
RFC: Do we want to multithread by default?

### DIFF
--- a/src/lu.jl
+++ b/src/lu.jl
@@ -59,7 +59,7 @@ if CUSTOMIZABLE_PIVOT
     end
 end
 
-function lu!(A, pivot = Val(true), thread = Val(true); check = true, kwargs...)
+function lu!(A, pivot = Val(true), thread = Val(false); check = true, kwargs...)
     m, n = size(A)
     minmn = min(m, n)
     npivot = normalize_pivot(pivot)
@@ -87,7 +87,7 @@ recurse(_) = false
 _ptrarray(ipiv) = PtrArray(ipiv)
 _ptrarray(ipiv::NotIPIV) = ipiv
 function lu!(A::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer},
-    pivot = Val(true), thread = Val(true);
+    pivot = Val(true), thread = Val(false);
     check::Bool = true,
     # the performance is not sensitive wrt blocksize, and 8 is a good default
     blocksize::Integer = length(A) ≥ 40_000 ? 8 : 16,

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -18,7 +18,7 @@ if VERSION >= v"1.7.0-DEV.1188"
     to_stdlib_pivot(::Val{false}) = LinearAlgebra.NoPivot()
 end
 
-function lu(A::AbstractMatrix, pivot = Val(true), thread = Val(true); kwargs...)
+function lu(A::AbstractMatrix, pivot = Val(true), thread = Val(false); kwargs...)
     return lu!(copy(A), normalize_pivot(pivot), thread; kwargs...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,17 +49,17 @@ testlu(A::Union{Transpose, Adjoint}, MF, BF, p) = testlu(parent(A), parent(MF), 
                 MF = mylu(A, p)
                 BF = baselu(A, p)
                 testlu(A, MF, BF, _p)
-                testlu(A, mylu(A, p, Val(false)), BF, false)
+                testlu(A, mylu(A, p, Val(true)), BF, false)
                 A′ = permutedims(A)
                 MF′ = mylu(A′', p)
                 testlu(A′', MF′, BF, _p)
-                testlu(A′', mylu(A′', p, Val(false)), BF, false)
+                testlu(A′', mylu(A′', p, Val(true)), BF, false)
                 i = rand(1:s) # test `MF.info`
                 A[:, i] .= 0
                 MF = mylu(A, p, check = false)
                 BF = baselu(A, p, check = false)
                 testlu(A, MF, BF, _p)
-                testlu(A, mylu(A, p, Val(false), check = false), BF, false)
+                testlu(A, mylu(A, p, Val(true), check = false), BF, false)
             end
         end
     end


### PR DESCRIPTION
The argument against is that we don't get good scaling anyway.

Defaulting to single threaded is predictable, and makes sure we play well when used (for example) from ensemble methods.
LinearSolve is likely to switch to MKL for larger sizes where multithreading becomes profitable.