### PR TITLE
Add compat on LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 TriangularSolve = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
 
 [compat]
+LinearAlgebra = "1.5"
 LoopVectorization = "0.10,0.11, 0.12"
 Polyester = "0.3.2,0.4.1, 0.5, 0.6, 0.7"
 PrecompileTools = "1"


### PR DESCRIPTION
The registration didn't go through because it's missing stdlib compats