### PR TITLE
Allow passing check as a `Val`, because constprop fails.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveFactorization"
 uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>"]
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Because `checknonsingular` is potentially allocating, we need const prop to eliminate the call to be compatible with `GPUCompiler` codegeneration/static compilation.