### PR TITLE
Use `square_view` to avoid square check, instead of `new` hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1', '1.6']
+        julia-version: ['1']
         threads:
           - '1'
           - '3'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveFactorization"
 uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>"]
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -18,7 +18,7 @@ Polyester = "0.3.2,0.4.1, 0.5, 0.6, 0.7"
 PrecompileTools = "1"
 StrideArraysCore = "0.5.5"
 TriangularSolve = "0.2"
-julia = "1.5"
+julia = "1.10"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,8 @@ LinearAlgebra = "1.5"
 LoopVectorization = "0.10,0.11, 0.12"
 Polyester = "0.3.2,0.4.1, 0.5, 0.6, 0.7"
 PrecompileTools = "1"
-StrideArraysCore = "0.1.13, 0.2.1, 0.3, 0.4.1, 0.5"
-TriangularSolve = "0.1.1"
+StrideArraysCore = "0.5.5"
+TriangularSolve = "0.2"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
This also switches to `TriangularSolve@0.2`, which doesn't use any internal buffers, increasing the static-compileability of RecursiveFactorization.